### PR TITLE
Make options more easily configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,12 @@ This is a very simple module and does not include a lot of features. It is only 
 ```puppet
 class { 'consular':
   ensure        => 'latest',
-  consular_args => [
-    "--host=127.0.0.1",
-    "--sync-interval=300",
-    '--purge', # TODO: Make configurable
-    "--registration-id=$::hostname",
-    "--consul=http://127.0.0.1:8500",
-    "--marathon=http://127.0.0.1:8080",
-  ],
+  host          => $::ipaddress_eth0,
+  port          => 7070,
+  consul        => 'http://127.0.0.1:8500',
+  marathon      => 'http://127.0.0.1:8080',
+  sync_interval => 300,
+  purge         => true,
 }
 ```
+For a full list of options see the [manifest source](manifests/init.pp).

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,12 +7,63 @@
 # [*ensure*]
 #   The ensure value for the package.
 #
-# [*consular_args*]
-#   A list of arguments to pass to Consular at runtime.
+# [*host*]
+#   The address for Consular to listen on for connections from Marathon.
+#
+# [*port*]
+#   The port for Consular to listen on for connections from Marathon.
+#
+# [*consul*]
+#   The full address to use to connect to Consul.
+#
+# [*marathon*]
+#   The full address to use to connect to Marathon.
+#
+# [*registration_id*]
+#   The registration ID to use when registering for callbacks with Marathon.
+#
+# [*sync_interval*]
+#   The number of seconds between syncs. If 0, syncing will be disabled.
+#
+# [*purge*]
+#   Whether or not to purge old Consular-registered services during syncs.
+#
+# [*opts*]
+#   A hash of additional options to pass to Consular. NOTE: these options can
+#   override any of the above options.
+#   e.g. { 'timeout' => 10 }
 class consular (
-  $ensure        = 'installed',
-  $consular_args = [],
+  $ensure          = 'installed',
+  $host            = $::ipaddress_lo,
+  $port            = 7000,
+  $consul          = "http://${::ipaddress_lo}:8500",
+  $marathon        = "http://${::ipaddress_lo}:8080",
+  $registration_id = $::hostname,
+  $sync_interval   = 0,
+  $purge           = false,
+  $opts            = {},
 ) {
+  validate_ip_address($host)
+  validate_integer($port)
+  validate_integer($sync_interval)
+  validate_bool($purge)
+  validate_hash($opts)
+
+  $purge_flag = $purge ? {
+    true  => 'purge',
+    false => 'no-purge',
+  }
+  $base_opts = {
+    'host'            => $host,
+    'port'            => $port,
+    'consul'          => $consul,
+    'marathon'        => $marathon,
+    'registration-id' => $registration_id,
+    'sync-interval'   => $sync_interval,
+    "${purge_flag}"   => '',
+  }
+  $final_opts = merge($base_opts, $opts)
+
   include apt
   # NOTE: This is a temporary PPA that is managed manually by a single
   # individual in his personal capacity. It needs to be replaced with a better

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@
 # [*purge*]
 #   Whether or not to purge old Consular-registered services during syncs.
 #
-# [*opts*]
+# [*extra_opts*]
 #   A hash of additional options to pass to Consular. NOTE: these options can
 #   override any of the above options.
 #   e.g. { 'timeout' => 10 }
@@ -41,13 +41,13 @@ class consular (
   $registration_id = $::hostname,
   $sync_interval   = 0,
   $purge           = false,
-  $opts            = {},
+  $extra_opts      = {},
 ) {
   validate_ip_address($host)
   validate_integer($port)
   validate_integer($sync_interval)
   validate_bool($purge)
-  validate_hash($opts)
+  validate_hash($extra_opts)
 
   $purge_flag = $purge ? {
     true  => 'purge',
@@ -62,7 +62,7 @@ class consular (
     'sync-interval'   => $sync_interval,
     "${purge_flag}"   => '',
   }
-  $final_opts = merge($base_opts, $opts)
+  $final_opts = merge($base_opts, $extra_opts)
 
   include apt
   # NOTE: This is a temporary PPA that is managed manually by a single

--- a/templates/init.conf.erb
+++ b/templates/init.conf.erb
@@ -4,4 +4,4 @@ start on stopped rc RUNLEVEL=[2345]
 respawn
 
 exec /usr/bin/consular<%
-  @consular_args.each do |arg| %> <%= arg %><% end %>
+  @final_opts.each do |k, v| %> <%= "--#{k} #{v}" %><% end %>


### PR DESCRIPTION
Imagine:

``` puppet
class { 'consular':
  ensure => 'latest',
  listen_addr => $::ipaddress_lo,
  port => 7000,
  sync_interval => 300,
  purge => true,
  registration_id => $::hostname,
  consul_addr => $::ipaddress_lo,
  marathon_addr => $::ipaddress_lo,
}
```
